### PR TITLE
Support go16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 go:
+  - 1.6.x
   - 1.7.5
 
 os:

--- a/_example/attachments/add.go
+++ b/_example/attachments/add.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/crowi/go-crowi"
 	"github.com/k0kubun/pp"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/_example/attachments/list.go
+++ b/_example/attachments/list.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/crowi/go-crowi"
 	"github.com/k0kubun/pp"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/_example/pages/create.go
+++ b/_example/pages/create.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/crowi/go-crowi"
 	"github.com/k0kubun/pp"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/_example/pages/get.go
+++ b/_example/pages/get.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/crowi/go-crowi"
 	"github.com/k0kubun/pp"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/_example/pages/list.go
+++ b/_example/pages/list.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"context"
 	"log"
 	"os"
 	"time"
 
 	"github.com/crowi/go-crowi"
 	"github.com/k0kubun/pp"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/_example/pages/update.go
+++ b/_example/pages/update.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/crowi/go-crowi"
 	"github.com/k0kubun/pp"
+	"golang.org/x/net/context"
 )
 
 func main() {

--- a/attachemnts.go
+++ b/attachemnts.go
@@ -1,10 +1,11 @@
 package crowi
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // AttachmentsService handles communication with the Attachments related

--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
 )
 
 const version = "0.1"
@@ -99,13 +100,12 @@ func (c *Client) newRequest(ctx context.Context, method string, uri string, para
 	if err != nil {
 		return err
 	}
-	req = req.WithContext(ctx)
 	req.Header.Set("User-Agent", userAgent)
 	if params != nil {
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
 
-	resp, err := c.Do(req)
+	resp, err := ctxhttp.Do(ctx, &c.Client, req)
 	if err != nil {
 		return err
 	}
@@ -159,11 +159,10 @@ func (c *Client) newRequestWithFile(ctx context.Context, method string, uri stri
 	if err != nil {
 		return err
 	}
-	req = req.WithContext(ctx)
 	req.Header.Add("Content-Type", "multipart/form-data; boundary="+mw.Boundary())
 	req.Header.Set("User-Agent", userAgent)
 
-	resp, err := c.Do(req)
+	resp, err := ctxhttp.Do(ctx, &c.Client, req)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -2,7 +2,6 @@ package crowi
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -16,6 +15,8 @@ import (
 	"path"
 	"runtime"
 	"strings"
+
+	"golang.org/x/net/context"
 )
 
 const version = "0.1"

--- a/pages.go
+++ b/pages.go
@@ -1,11 +1,12 @@
 package crowi
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // PagesService handles communication with the Pages related


### PR DESCRIPTION
Support go1.6 runtime.

I want to use go-crowi on GAE, but GAE go1.8 still unstable, unfortunately.
So, I removed `req.WithContext` and use `ctxhttp` package.
I don't know which is better way, but that's also uses [google-cloud-go/compute/metadata/metadata.go](https://github.com/GoogleCloudPlatform/google-cloud-go/blob/master/compute/metadata/metadata.go).